### PR TITLE
feat: Hintsのフォントサイズを小さくする

### DIFF
--- a/setting.js
+++ b/setting.js
@@ -167,7 +167,7 @@ const hintsCharactersLeft = "aoeui;qjkx";
 const hintsCharactersAll = hintsCharactersRight + hintsCharactersLeft;
 
 Hints.charactersUpper = false;
-Hints.style("font-size: 16px !important;");
+Hints.style("font-size: 15px !important;");
 settings.hintAlign = "left";
 
 // キーボードでリンクを移動。


### PR DESCRIPTION
Haddockでのリンク移動が絶妙に被って読みにくいので、
中途半端ですが少し小さくします。