### PR TITLE
feat: ヒントに使う文字を押しやすいものだけに限定し順番を対称にする

### DIFF
--- a/setting.js
+++ b/setting.js
@@ -162,8 +162,8 @@ mapkey("d", "#3Outdent parent tab", () => {
 
 // Hints。
 
-const hintsCharactersRight = "htnsdcrbmwvz";
-const hintsCharactersLeft = "aoeui;qjkx";
+const hintsCharactersRight = "htnsbmwvz";
+const hintsCharactersLeft = "ueoakjq;";
 const hintsCharactersAll = hintsCharactersRight + hintsCharactersLeft;
 
 Hints.charactersUpper = false;


### PR DESCRIPTION
人差し指を伸ばさなければ行けない`x`, `i`, `d`や上段である`c`, `r`を削除。
左側の順番を右側と対称にする。
キーボードの並び方が斜めになっているので`b`は押しやすいと判断して残す。