### PR TITLE
Revert "Merge pull request #34 from ncaq/hints-prefer-near-key"

### DIFF
--- a/setting.js
+++ b/setting.js
@@ -165,7 +165,7 @@ mapkey("d", "#3Outdent parent tab", () => {
 
 // Hints。
 
-const hintsCharactersRight = "htnscrbmwvz";
+const hintsCharactersRight = "htnsbmwvzcr";
 const hintsCharactersLeft = "ueoakjq;";
 const hintsCharactersAll = hintsCharactersRight + hintsCharactersLeft;
 


### PR DESCRIPTION
This reverts commit 511bf1f95088742c814d4d11747aa7714a7d8779, reversing changes made to 2809f9ab433da4f5635b9e107f232126efd73513.

よく考えてみると`b`や`m`でヒントを指導した場合は近くならないのでなるべく下段に集中した方が良さそう。