### PR TITLE
feat: `hintsCharactersAll`を単に連結させるのではなく押しやすい順番に変更

### DIFF
--- a/setting.js
+++ b/setting.js
@@ -165,9 +165,9 @@ mapkey("g", "#3Outdent parent tab", () => {
 
 // Hints。
 
-const hintsCharactersRight = "crdhtnsbmwvz";
+const hintsCharactersRight = "dhtnsbmwvzcr";
 const hintsCharactersLeft = "iueoakjq;";
-const hintsCharactersAll = hintsCharactersRight + hintsCharactersLeft;
+const hintsCharactersAll = "crhtnsueoabmwvzkjq;";
 
 Hints.charactersUpper = false;
 Hints.style("font-size: 14px !important;");


### PR DESCRIPTION
両手を使うことを前提に変える。
両手分のヒントキーがあるなら量は十分なため押しやすいものだけに限定。
`hintsCharactersRight`も主に`d`で始動することを前提に変更。
