### PR TITLE
feat: TweetDeckのURLをx.comに正規化

### DIFF
--- a/setting.js
+++ b/setting.js
@@ -326,7 +326,7 @@ function tabActivateOrCreate(urlPattern, urlOpen = undefined) {
 }
 
 mapkey("<Ctrl-;>", "#3XPro", () => {
-  tabActivateOrCreate("https://pro.twitter.com/*");
+  tabActivateOrCreate("https://pro.x.com/*");
 });
 
 mapkey("<Alt-;>", "#3通知 / X", () => {


### PR DESCRIPTION
別にどっちでも良いんですが、
たまにリダイレクトされると規則性がないので正規化しておきます。
