### PR TITLE
refactor: コメントと型表記の可読性を改善

### DIFF
--- a/setting.js
+++ b/setting.js
@@ -122,10 +122,11 @@ mapkey("q", "#3Close current tab", () => {
 // タブ一覧を表示して移動。
 map("x", "T");
 
-// 最近閉じたタブや履歴を閲覧。
+// 最近閉じたタブを表示して移動。
 mapkey("<Alt-,>", "#8Open RecentlyClosed", () => {
   Front.openOmnibar({ type: "RecentlyClosed" });
 });
+// 最近の履歴を表示して移動。
 mapkey("<Ctrl-Alt-,>", "#8Open History", () => {
   Front.openOmnibar({ type: "History" });
 });

--- a/setting.js
+++ b/setting.js
@@ -163,7 +163,7 @@ function getTreeTabs(tabs) {
 mapkey("r", "#3Focus parent tab", async () => {
   const { id } = await getTreeTab("current");
   const tabs = await getTreeTabs("*");
-  const parentTab = tabs.find((tab) => tab.children.find((child) => child.id === id));
+  const parentTab = tabs.find((tab) => tab.children.some((child) => child.id === id));
   if (parentTab) {
     browser.runtime.sendMessage(tstId, {
       type: "focus",

--- a/setting.js
+++ b/setting.js
@@ -3,12 +3,15 @@
  * @copyright ncaq
  * @license MIT
  *
- * This configuration is partly based on https://github.com/brookhong/Surfingkeys default settings.
+ * This configuration is partly based on
+ * https://github.com/brookhong/Surfingkeys default settings.
+ *
  * Surfingkeys is MIT licensed.
  * Copyright (c) 2015 brookhong
  */
 
-// `Clipboard`はDOMの組み込みグローバル名と衝突するのでdestructureせずに`api.Clipboard`経由で参照する。
+// `Clipboard`はDOMの組み込みグローバル名と衝突するので、
+// destructureせずに`api.Clipboard`経由で参照する。
 const { Front, Hints, RUNTIME, iunmap, map, mapkey, tabOpenLink, unmap } = api;
 
 // 無効化。

--- a/setting.js
+++ b/setting.js
@@ -139,7 +139,7 @@ const tstId = "treestyletab@piro.sakura.ne.jp";
  * @typedef {{ id: number; children: TstTab[] }} TstTab
  */
 
-// 親のタブに移る
+// 親のタブに移る。
 mapkey("r", "#3Focus parent tab", async () => {
   const { id } = /** @type {TstTab} */ (
     await browser.runtime.sendMessage(tstId, {
@@ -162,7 +162,7 @@ mapkey("r", "#3Focus parent tab", async () => {
   }
 });
 
-// タブを1段階上昇させる
+// タブを1段階上昇させる。
 mapkey("g", "#3Outdent parent tab", () => {
   browser.runtime.sendMessage(tstId, {
     type: "outdent",

--- a/setting.js
+++ b/setting.js
@@ -136,23 +136,33 @@ mapkey("<Ctrl-Alt-,>", "#8Open History", () => {
 const tstId = "treestyletab@piro.sakura.ne.jp";
 
 /**
- * @typedef {{ id: number; children: TstTab[] }} TstTab
+ * Tree Style Tabsのタブを1つ取得します。
+ * @param {string} tab
+ * @return {Promise<TstTab>}
  */
+function getTreeTab(tab) {
+  return browser.runtime.sendMessage(tstId, {
+    type: "get-tree",
+    tab,
+  });
+}
+
+/**
+ * Tree Style Tabsのタブを複数取得します。
+ * @param {string} tabs
+ * @return {Promise<TstTab[]>}
+ */
+function getTreeTabs(tabs) {
+  return browser.runtime.sendMessage(tstId, {
+    type: "get-tree",
+    tabs,
+  });
+}
 
 // 親のタブに移る。
 mapkey("r", "#3Focus parent tab", async () => {
-  const { id } = /** @type {TstTab} */ (
-    await browser.runtime.sendMessage(tstId, {
-      type: "get-tree",
-      tab: "current",
-    })
-  );
-  const tabs = /** @type {TstTab[]} */ (
-    await browser.runtime.sendMessage(tstId, {
-      type: "get-tree",
-      tabs: "*",
-    })
-  );
+  const { id } = await getTreeTab("current");
+  const tabs = await getTreeTabs("*");
   const parentTab = tabs.find((tab) => tab.children.find((child) => child.id === id));
   if (parentTab) {
     browser.runtime.sendMessage(tstId, {

--- a/surfingkeys.d.ts
+++ b/surfingkeys.d.ts
@@ -48,6 +48,14 @@ declare const settings: {
 // このプロジェクトでは利用箇所が限定的なので最小限の型のみ宣言する。
 declare const browser: {
   runtime: {
-    sendMessage(extensionId: string, message: unknown): Promise<unknown>;
+    sendMessage(extensionId: string, message: T): Promise<U>;
   };
 };
+
+// Tree Style TabのAPI。
+// 厳密にはSurfingkeysの一部ではありませんが、
+// この設定ファイルで利用するために書いておきます。
+interface TstTab {
+  id: number;
+  children: TstTab[];
+}

--- a/surfingkeys.d.ts
+++ b/surfingkeys.d.ts
@@ -48,7 +48,10 @@ declare const settings: {
 // このプロジェクトでは利用箇所が限定的なので最小限の型のみ宣言する。
 declare const browser: {
   runtime: {
-    sendMessage(extensionId: string, message: T): Promise<U>;
+    sendMessage<Message = unknown, Response = unknown>(
+      extensionId: string,
+      message: Message,
+    ): Promise<Response>;
   };
 };
 


### PR DESCRIPTION
設定ファイル周辺のコメントと型定義の見た目を整える小さなスタイル調整をまとめました。

具体的には以下を行っています。

- コメントの改行位置や記述粒度を整え、それぞれの記述が独立した単位として読めるようにしました。
- コメントの文末に句点を付け足し、文章としての体裁を統一しました。
- Tree Style Tabの取得処理に使われていた入り組んだ型表記を独立した関数に分割し、読みやすくしました。

挙動には変更はなく、設定ファイルを読み返したときの理解しやすさを高めることが目的です。
