### PR TITLE
refactor(eslint): JavaScript向けにも型関連ESLintルールを適用するよう整備

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -85,10 +85,7 @@ const config: ReturnType<typeof defineConfig> = defineConfig(
     files: ["**/*.{js,jsx,cjs,mjs}"],
     languageOptions: {
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ["*.js", "*.jsx", "*.cjs", "*.mjs"],
-        },
-        project: ["tsconfig.json"],
+        projectService: true,
         tsconfigRootDir: __dirname,
       },
     },

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -62,7 +62,7 @@ const config: ReturnType<typeof defineConfig> = defineConfig(
     files: ["**/*.{ts,tsx,cts,mts}"],
     languageOptions: {
       parserOptions: {
-        project: ["tsconfig.json"],
+        projectService: true,
         tsconfigRootDir: __dirname,
       },
     },

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -27,7 +27,7 @@ const config: ReturnType<typeof defineConfig> = defineConfig(
   {
     rules: {
       // 名前別だけではなくカテゴリ別にもソートします。
-      "import-x/order": ["warn", { alphabetize: { order: "asc", orderImportKind: "asc" } }],
+      "import-x/order": ["error", { alphabetize: { order: "asc", orderImportKind: "asc" } }],
     },
     settings: {
       // TypeScriptのimportを柔軟に解決できるようにします。
@@ -72,8 +72,6 @@ const config: ReturnType<typeof defineConfig> = defineConfig(
         "error",
         {
           allowExpressions: true, // インラインな関数式にはいちいち要求しません。
-          allowConciseArrowFunctionExpressionsStartingWithVoid: true, // voidを返すことが明白な場合は要求しません。
-          allowIIFEs: true, // 即時実行関数の型を持ってもあまり意味がないので要求しません。
         },
       ],
     },
@@ -94,14 +92,14 @@ const config: ReturnType<typeof defineConfig> = defineConfig(
         tsconfigRootDir: __dirname,
       },
     },
-    ...tseslint.configs.disableTypeChecked, // JavaScriptではESLint側での型チェックが必要なルールは無効化。
   },
   {
     // Node.js向けのルール。
     plugins: { n: node },
     extends: ["n/recommended-module"],
     rules: {
-      // 複雑な設定下でのimportを解決できないため無効化します。eslint-plugin-import-xがあるため問題になりません。
+      // 複雑な設定下でのimportを解決できないため無効化します。
+      // eslint-plugin-import-xに任せます。
       "n/no-missing-import": "off",
       // Node.jsビルトインのモジュールをimportする時にprefixを強制して依存をわかりやすくします。
       "n/prefer-node-protocol": "error",
@@ -141,5 +139,5 @@ const config: ReturnType<typeof defineConfig> = defineConfig(
   },
 );
 // ESLintの設定をエクスポート。
-// 型定義とdefault exportが両立できないため分けています。
+// 型アノテーションとdefault exportが両立できないため分けています。
 export default config;

--- a/setting.js
+++ b/setting.js
@@ -493,6 +493,23 @@ mapkey("L", "#7Copy title and link to human readable", () => {
 });
 
 /**
+ * oembedのレスポンスの型かどうかを判定します。
+ * @param {unknown} value
+ * @returns {value is { html: string }}
+ */
+function isOembed(value) {
+  if (
+    value == null ||
+    typeof value !== "object" ||
+    !("html" in value) ||
+    typeof value.html !== "string"
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
  * Twitterの埋め込みスクリプトをボタンを押さずに取得します。
  * @param {URL} url
  * @returns {Promise<string | undefined>}
@@ -521,12 +538,7 @@ async function getTwitterEmbed(url) {
   }
   /** @type {unknown} */
   const oembed = await response.json();
-  if (
-    oembed == null ||
-    typeof oembed !== "object" ||
-    !("html" in oembed) ||
-    typeof oembed.html !== "string"
-  ) {
+  if (!isOembed(oembed)) {
     throw new Error(`${publish.href}: response shape is unexpected`);
   }
   return oembed.html;

--- a/setting.js
+++ b/setting.js
@@ -165,7 +165,7 @@ mapkey("r", "#3Focus parent tab", async () => {
   const tabs = await getTreeTabs("*");
   const parentTab = tabs.find((tab) => tab.children.some((child) => child.id === id));
   if (parentTab) {
-    browser.runtime.sendMessage(tstId, {
+    void browser.runtime.sendMessage(tstId, {
       type: "focus",
       tab: parentTab.id,
     });
@@ -174,7 +174,7 @@ mapkey("r", "#3Focus parent tab", async () => {
 
 // タブを1段階上昇させる。
 mapkey("g", "#3Outdent parent tab", () => {
-  browser.runtime.sendMessage(tstId, {
+  void browser.runtime.sendMessage(tstId, {
     type: "outdent",
     tab: "current",
   });
@@ -465,9 +465,9 @@ function backlogTitle() {
  */
 function dwimTitle() {
   return (
-    githubCommitInPullRequestTitle() ||
-    codeCommitPullRequestTitle() ||
-    backlogTitle() ||
+    githubCommitInPullRequestTitle() ??
+    codeCommitPullRequestTitle() ??
+    backlogTitle() ??
     document.title
   );
 }
@@ -519,7 +519,17 @@ async function getTwitterEmbed(url) {
   if (!response.ok) {
     throw new Error(`${publish.href}: response is not ok ${JSON.stringify(response.statusText)}`);
   }
-  return (await response.json()).html;
+  /** @type {unknown} */
+  const oembed = await response.json();
+  if (
+    oembed == null ||
+    typeof oembed !== "object" ||
+    !("html" in oembed) ||
+    typeof oembed.html !== "string"
+  ) {
+    throw new Error(`${publish.href}: response shape is unexpected`);
+  }
+  return oembed.html;
 }
 
 // ツイートを埋め込むボタンを押していちいちコピーして`script`タグを取り除くのが面倒なので、
@@ -531,7 +541,7 @@ mapkey("ye", "#7Copy Twitter embed", () => {
       api.Clipboard.write(embed);
     }
   }
-  f();
+  void f();
 });
 
 // zoom

--- a/surfingkeys.d.ts
+++ b/surfingkeys.d.ts
@@ -27,11 +27,11 @@ declare const api: {
     options?: unknown,
     callback?: (response: { tabs?: { id?: number }[] }) => void,
   ) => void;
-  iunmap(keystroke: string): void;
-  map(newKeystroke: string, oldKeystroke: string): void;
-  mapkey(keys: string, annotation: string, jscode: () => void | Promise<unknown>): void;
-  tabOpenLink(url: string): void;
-  unmap(keystroke: string): void;
+  iunmap(this: void, keystroke: string): void;
+  map(this: void, newKeystroke: string, oldKeystroke: string): void;
+  mapkey(this: void, keys: string, annotation: string, jscode: () => void | Promise<unknown>): void;
+  tabOpenLink(this: void, url: string): void;
+  unmap(this: void, keystroke: string): void;
 };
 
 declare const settings: {


### PR DESCRIPTION
ESLint設定を整えて、
`@ts-check`を有効化した`setting.js`にも型関連ルールが実際に効くようにします。

`disableTypeChecked`を外して型認識のあるリントを走らせる方針に切り替え、
`projectService`と`project`の重複指定や`allowDefaultProject`といった不要な設定を整理しました。
`setting.js`は`tsconfig.json`の`checkJs`により暗黙的にプロジェクトに含まれるため、
`projectService: true`の宣言だけで十分です。

合わせて、`import-x/order`の警告レベルを`error`へ引き上げ、
`@typescript-eslint/explicit-function-return-type`の許容オプションを縮めて、
関数の戻り値型を明示する範囲を広げました。

型認識のあるリントが走るようになった結果、
`setting.js`から新たに13件のエラーが検出されました。
これらはコードの意味を変えない範囲で個別に解消しています。
`api`から分割代入する関数群の`unbound-method`は`surfingkeys.d.ts`に`this: void`を付与して回避し、
非同期処理のfire-and-forgetは`void`演算子で意図を明示し、
`||`は`??`へ置き換え、
`response.json()`の戻り値は`unknown`として受け取り型ガードを介して取り出すよう変更しました。
