### PR TITLE
build(deps-dev): Node.jsのバージョン要件を22.22.2以上に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "typescript-eslint": "8.59.4"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.22.2"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "typescript-eslint": "8.59.4"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.22.2"
   }
 }


### PR DESCRIPTION
メジャーバージョンだけではなく全体のバージョンを記述。
値は現在のnixpkgsのstableのデフォルトバージョンになっています。
`@types/node`は調べたら特に更新はないみたいなので放置しています。
